### PR TITLE
configure plugins first

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,4 +12,3 @@ build-docker-image:
   variables:
     BUILDER_IMAGE: "images/mirror/golang:1.22.1"
     DOCKERFILE_NAME: "Dockerfile.dd"
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,58 @@
-ARG BASE_IMAGE
-# See
-# https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
-# for info on BUILDPLATFORM, TARGETOS, TARGETARCH, etc.
-FROM --platform=$BUILDPLATFORM golang:1.22.2 AS builder
-WORKDIR /go/src/github.com/bank-vaults
-ENV CGO_ENABLED=1
-COPY go.* .
-ARG GOPROXY
-RUN go mod download
-COPY . .
-ARG TARGETOS
-ARG TARGETARCH
-RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /go/src/github.com/bank-vaults ./cmd/bank-vaults/
-RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /go/src/github.com/template ./cmd/template/
+FROM --platform=$BUILDPLATFORM tonistiigi/xx:1.4.0@sha256:0cd3f05c72d6c9b038eb135f91376ee1169ef3a330d34e418e65e2a5c2e9c0d4 AS xx
 
-FROM $BASE_IMAGE
-COPY --from=builder /go/src/github.com/bank-vaults /bin/bank-vaults
-COPY --from=builder /go/src/github.com/template /bin/template
-COPY --from=builder /go/src/github.com/bank-vaults/scripts/pcscd-entrypoint.sh /bin/pcscd-entrypoint.sh
-ENTRYPOINT ["/bin/bank-vaults/bank-vaults"]
+FROM --platform=$BUILDPLATFORM golang:1.22.2-alpine3.18@sha256:d995eb689a0c123590a3d34c65f57f3a118bda3fa26f92da5e089ae7d8fd81a0 AS builder
+
+COPY --from=xx / /
+
+RUN apk add --update --no-cache ca-certificates make git curl clang lld
+
+ARG TARGETPLATFORM
+
+RUN xx-apk --update --no-cache add musl-dev gcc
+
+RUN xx-go --wrap
+
+WORKDIR /usr/local/src/bank-vaults
+
+ARG GOPROXY
+
+ENV CGO_ENABLED=1
+
+COPY go.* ./
+RUN go mod download
+
+COPY . .
+
+RUN go build -o /usr/local/bin/bank-vaults ./cmd/bank-vaults/
+RUN xx-verify /usr/local/bin/bank-vaults
+
+RUN go build -o /usr/local/bin/template ./cmd/template/
+RUN xx-verify /usr/local/bin/template
+
+FROM alpine:3.19.1@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b AS common
+
+RUN apk add --update --no-cache ca-certificates tzdata
+
+# Install tools for accessing smart cards
+RUN apk add --no-cache ccid opensc pcsc-lite-libs
+
+COPY --from=builder /usr/local/bin/bank-vaults /usr/local/bin/bank-vaults
+COPY --from=builder /usr/local/bin/template /usr/local/bin/template
+COPY --from=builder /usr/local/src/bank-vaults/scripts/pcscd-entrypoint.sh /usr/local/bin/pcscd-entrypoint.sh
+
+ENTRYPOINT ["bank-vaults"]
+
+FROM common AS softhsm
+
+RUN apk add --no-cache softhsm
+
+USER 65534
+
+# Initializing SoftHSM to be able to create a working example (only for dev),
+# sharing the HSM device is emulated with a pre-created keypair in the image.
+RUN softhsm2-util --init-token --free --label bank-vaults --so-pin bank-vaults --pin bank-vaults
+RUN pkcs11-tool --module /usr/lib/softhsm/libsofthsm2.so --keypairgen --key-type rsa:2048 --pin bank-vaults --token-label bank-vaults --label bank-vaults
+
+FROM common
+
+USER 65534

--- a/internal/vault/auth_methods.go
+++ b/internal/vault/auth_methods.go
@@ -104,6 +104,11 @@ func (v *vault) addAdditionalAuthConfig(authMethod auth) error {
 		if err != nil {
 			return errors.Wrap(err, "error configuring github mappings for vault")
 		}
+	case "plugin":
+		err := v.configureGenericAuthRoles(authMethod.Type, authMethod.Path, "role", authMethod.Roles)
+		if err != nil {
+			return errors.Wrap(err, "error configuring plugin auth roles for vault")
+		}
 	case "aws":
 		err := v.configureAwsConfig(authMethod.Path, authMethod.Config)
 		if err != nil {

--- a/internal/vault/operator_client.go
+++ b/internal/vault/operator_client.go
@@ -578,16 +578,16 @@ func (v *vault) Configure(config map[string]interface{}) error {
 		return errors.Wrap(err, "error configuring audit devices for vault")
 	}
 
+	if err = v.configurePlugins(); err != nil {
+		return errors.Wrap(err, "error configuring plugins for vault")
+	}
+
 	if err = v.configureAuthMethods(); err != nil {
 		return errors.Wrap(err, "error configuring auth methods for vault")
 	}
 
 	if err = v.configureIdentityGroups(); err != nil {
 		return errors.Wrap(err, "error writing groups configurations for vault")
-	}
-
-	if err = v.configurePlugins(); err != nil {
-		return errors.Wrap(err, "error configuring plugins for vault")
 	}
 
 	if err = v.configurePolicies(); err != nil {


### PR DESCRIPTION
To be able to use a plugin as authentication backend, we need the plugin to be loaded before authentication configuration happens.
Moreover, this PR introduces the needed changes for plugins to be used as authentication method. 

It would be used with a config file like the following:
```
auth:
- path: aws-iam
  type: plugin
  options:
    plugin_name: vault-plugin-auth-aws
  roles:
    - name: 'myRoleName'
      bound_iam_instance_profile_arn:
        - 'myInstanceProfile'
      ttl: 12h
      inferred_entity_type: ec2_instance
      inferred_aws_region: us-east-1
      auth_type: iam
      token_type: service
plugins:
- plugin_name: vault-plugin-auth-aws
  command: vault-plugin-auth-aws
  sha256: <sha256hash>
  type: auth
```

