### PR TITLE
update the build-docker-image job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,4 +11,4 @@ build-docker-image:
   extends: .build-docker-image
   variables:
     BUILDER_IMAGE: "images/mirror/golang:1.22.1"
-    DOCKERFILE_NAME: "Dockerfile.dd"
+    EXTRA_ARGS: "-f Dockerfile.dd"


### PR DESCRIPTION
This PR reflects the change made in compute-delivery: https://github.com/DataDog/compute-delivery/pull/192