### PR TITLE
add support for AWS Identity Integration

### DIFF
--- a/internal/vault/auth_methods.go
+++ b/internal/vault/auth_methods.go
@@ -120,7 +120,6 @@ func (v *vault) addAdditionalAuthConfig(authMethod auth) error {
 				return errors.Wrap(err, "error configuring aws auth cross account roles for vault")
 			}
 		}
-
 		err = v.configureGenericAuthRoles(authMethod.Type, authMethod.Path, "role", authMethod.Roles)
 		if err != nil {
 			return errors.Wrap(err, "error configuring aws auth roles for vault")

--- a/internal/vault/auth_methods.go
+++ b/internal/vault/auth_methods.go
@@ -446,12 +446,11 @@ func (v *vault) addManagedAuthMethods(managedAuths []auth) error {
 
 		// This configuration only makes sense if authentication is done against AWS
 		// However, AWS authentication can be configured using an "aws" or "plugin" backend.
-		// Since it's not specific for only one backend type, I put this code here,
+		// Since it's not specific for only one backend type,
+		// this code lives in this function rather than in addAdditionalAuthConfig
 		if authMethod.Config != nil {
-			slog.Info(fmt.Sprintf("ikraemer - auth method config: %s", authMethod.Config))
-			// Generic configuration of Plugin authentication, YAML config file should have the proper format
 			for configOption, configDataRaw := range authMethod.Config {
-				slog.Info(fmt.Sprintf("ikraemer - auth method config option: %s", configOption))
+				slog.Debug(fmt.Sprintf("Handling auth method config option: %s", configOption))
 				switch configOption {
 				case "aws-identity-integration":
 					configData, err := cast.ToStringMapE(configDataRaw)


### PR DESCRIPTION
Bank vaults image now supports the configuration of AWS Identity Integration, see https://developer.hashicorp.com/vault/api-docs/auth/aws#configure-identity-integration. It is necessary to configure AWS Identity Integration for us to be able to leverage the `inferred_hostname` metadata in templated policies, like we plan to.

This code got tested here: https://github.com/DataDog/k8s-platform-resources/pull/10541 and works if the authentication is performed using AWS auth backend or plugin auth backend.
