### PR TITLE
add support for certificate issuance templated policies

### DIFF
--- a/internal/vault/secrets_engines.go
+++ b/internal/vault/secrets_engines.go
@@ -45,6 +45,12 @@ var secretEnginesWithoutNameConfig = map[string]bool{
 	"kv":       true,
 }
 
+// This object is used to easily find field in secret engines that contain potentially templated expressions
+type secretEngineTemplatedConfig struct {
+	AllowedDomains []string               `mapstructure:"allowed_domains"`
+	Other          map[string]interface{} `mapstructure:",remain"`
+}
+
 type secretEngine struct {
 	Path          string                 `mapstructure:"path"`
 	Type          string                 `mapstructure:"type"`
@@ -55,6 +61,16 @@ type secretEngine struct {
 	PluginName    string                 `mapstructure:"plugin_name"`
 	Local         bool                   `mapstructure:"local"`
 	SealWrap      bool                   `mapstructure:"seal_wrap"`
+}
+
+func replaceAccessor(input string, mounts map[string]*api.MountOutput) string {
+	for k, v := range mounts {
+		if strings.Contains(input, fmt.Sprintf("__accessor__%s", strings.TrimRight(k, "/"))) {
+			slog.Info(fmt.Sprintf("__accessor__ field replaced in string %s by accessor %s", input, v.Accessor))
+			return strings.ReplaceAll(input, fmt.Sprintf("__accessor__%s", strings.TrimRight(k, "/")), v.Accessor)
+		}
+	}
+	return input
 }
 
 func initSecretsEnginesConfig(configs []secretEngine) []secretEngine {
@@ -178,7 +194,7 @@ func configNeedsNoName(secretEngineType string, configOption string) bool {
 	return false
 }
 
-func (v *vault) addManagedSecretsEngines(managedSecretsEngines []secretEngine) error {
+func (v *vault) addManagedSecretsEngines(managedSecretsEngines []secretEngine, mounts map[string]*api.MountOutput) error {
 	b := &backoff.Backoff{
 		Min:    500 * time.Millisecond,
 		Max:    60 * time.Second,
@@ -253,10 +269,28 @@ func (v *vault) addManagedSecretsEngines(managedSecretsEngines []secretEngine) e
 			if err != nil {
 				return errors.Wrap(err, "error converting config data for secret engine")
 			}
-			for _, subConfigData := range configData {
-				subConfigData, err := cast.ToStringMapE(subConfigData)
-				if err != nil {
-					return errors.Wrap(err, "error converting sub config data for secret engine")
+			for _, subConfigDataRaw := range configData {
+				var subConfigData map[string]interface{}
+
+				// If subConfigDataRaw has fields that are supported for templated policies,
+				// it will be cast successfully into secretEngineTemplatedConfig
+				var pkiRole secretEngineTemplatedConfig
+				err := mapstructure.Decode(subConfigDataRaw, &pkiRole)
+				if err == nil {
+					templatedDomains := []string{}
+					for _, domain := range pkiRole.AllowedDomains {
+						templatedDomains = append(templatedDomains, replaceAccessor(domain, mounts))
+					}
+					pkiRole.AllowedDomains = templatedDomains
+					subConfigData = pkiRole.Other
+					subConfigData["allowed_domains"] = pkiRole.AllowedDomains
+				} else {
+					// If the object could not be cast into a secretEngineTemplatedConfig,
+					// subConfigData will just be initialized from the subConfigDataRaw
+					subConfigData, err = cast.ToStringMapE(subConfigDataRaw)
+					if err != nil {
+						return errors.Wrap(err, "error converting sub config data for secret engine")
+					}
 				}
 
 				name, ok := subConfigData["name"]
@@ -389,10 +423,14 @@ func (v *vault) removeUnmanagedSecretsEngines(unmanagedSecretsEngines map[string
 }
 
 func (v *vault) configureSecretsEngines() error {
+	auths, err := v.cl.Sys().ListAuth()
+	if err != nil {
+		return errors.Wrap(err, "error while getting list of auth engines for secret engine configuration")
+	}
 	managedSecretsEngines := initSecretsEnginesConfig(v.externalConfig.Secrets)
 	unmanagedSecretsEngines := v.getUnmanagedSecretsEngines(managedSecretsEngines)
 
-	if err := v.addManagedSecretsEngines(managedSecretsEngines); err != nil {
+	if err := v.addManagedSecretsEngines(managedSecretsEngines, auths); err != nil {
 		return errors.Wrap(err, "error adding secrets engines")
 	}
 


### PR DESCRIPTION
# Goal
This PR adds ability for the common name of the certificates to be signed to be templated, like explained in Hashicorp Vault [documentation](https://developer.hashicorp.com/vault/tutorials/policies/policy-templating).

# Tests

## Configuration file

Certificate signing policy with templated allowed_domain:
```
secrets:
[...]
- type: pki
  path: REDACTED
  description: K8S PKI Backend
  config:
    default_lease_ttl: REDACTEDh
    max_lease_ttl: REDACTEDh
  configuration:
    config:
    - name: urls
      crl_distribution_points: https://REDACTED
      issuing_certificates: https://REDACTED
    roles:
    - name: test
      allow_glob_domains: true
      allow_localhost: false
      allow_bare_domains: true
      allowed_domains_template: true
      allowed_domains:
      - system:node:{{identity.entity.aliases.${ accessor `aws-iam/` }.metadata.inferred_hostname}}
      enforce_hostnames: false
      [...]
```

## Check configuration
Check result as Vault admin:
```
$ vault read "$MOUNT_PATH/roles/test"
Key                                   Value
---                                   -----
[...]
allowed_domains                       [system:node:{{identity.entity.aliases.auth_vault-plugin-auth-aws_REDACTED.metadata.inferred_hostname}}]
```

## Check behaviour

Sign certificates matching the policy:
```
TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
HOSTNAME=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/local-hostname)
ORG="system:node"
CN="system:node:$HOSTNAME"

CSR_valid="csr_VALID_this_node_this_cluster.pem"
openssl req -new -sha256 -key my.key.pem -out "$CSR_valid" \
     -subj "/C=FR/ST=/L=/O=$ORG/OU=/CN=$CN" -nodes
vault write "$PKI_PATH"/sign/test csr=@$CSR_valid
```
returns a certificate, which is the expected behaviour..

Check that certificates not matching the policy cannot be signed:
```
CSR_invalid="csr_INVALID_another_node_this_cluster.pem"
openssl req -new -sha256 -key my.key.pem -out "$CSR_invalid" \
    -subj "/C=FR/ST=/L=/O=$ORG/OU=/CN=test" -nodes
vault write "$PKI_PATH"/sign/test csr=@$CSR_invalid

CSR_should_not_be_valid="csr_SHOULDBEINVALID_this_node_another_cluster.pem"
openssl req -new -sha256 -key my.key.pem -out "$CSR_should_not_be_valid" \
    -subj "/C=FR/ST=/L=/O=$ORG/OU=/CN=system:node:dummy" -nodes
vault write "$PKI_PATH"/sign/test csr=@$CSR_should_not_be_valid
```
They both return the following error, which is the expected behaviour.
```
Code: 400. Errors:

* common name xxx not allowed by this role
```