### PR TITLE
fix: plugin auth method configuration being ignored when config is provided

### DIFF
--- a/internal/vault/auth_methods.go
+++ b/internal/vault/auth_methods.go
@@ -99,6 +99,13 @@ func (v *vault) addAdditionalAuthConfig(authMethod auth) error {
 		}
 
 	case "plugin":
+		if authMethod.Config != nil {
+			err := v.configureGenericAuthConfig(authMethod.Type, authMethod.Path, authMethod.Config)
+			if err != nil {
+				return errors.Wrap(err, "error configuring plugin auth for vault")
+			}
+		}
+
 		err := v.configureGenericAuthRoles(authMethod.Type, authMethod.Path, "role", authMethod.Roles)
 		if err != nil {
 			return errors.Wrap(err, "error configuring plugin auth roles for vault")


### PR DESCRIPTION
# Overview
When configuring auth methods with `type: plugin`, the `config` map was completely ignored. Only roles were being configured. This meant that plugin-based auth methods (like Azure) that require configuration parameters couldn't be properly set up using the plugin type.

For example, this configuration would silently ignore the config section:
```yaml
- path: azure
  type: plugin
  config:
    tenant_id: <TENANT_ID>
    client_id: <CLIENT_ID>
    resource: "https://management.azure.com/"
```


This brings the plugin auth method handler in line with other auth method types like azure, gcp, kubernetes, etc., which all properly handle both config and roles.
#Fixes #(issue):
TBD

# Test Plan
- Deploy vault with a plugin-type auth method that requires config parameters
- Verify config is properly written to Vault at auth/<path>/config
- Verify roles continue to work as expected

