### PR TITLE
fix(aws): no such key panic

### DIFF
--- a/pkg/kv/s3/s3.go
+++ b/pkg/kv/s3/s3.go
@@ -94,7 +94,7 @@ func (s3Storage *s3Storage) Get(ctx context.Context, key string) ([]byte, error)
 	r, err := s3Storage.client.GetObject(ctx, &input)
 	if err != nil {
 		const ErrCodeNoSuchKey = "NoSuchKey"
-		var noSuchKeyError s3types.NoSuchKey
+		var noSuchKeyError *s3types.NoSuchKey
 		if errors.As(err, &noSuchKeyError) && noSuchKeyError.ErrorCode() == ErrCodeNoSuchKey {
 			return nil, kv.NewNotFoundError("error getting object for key '%s': %s", aws.ToString(input.Key), noSuchKeyError.Error())
 		}


### PR DESCRIPTION
 ## Summary

  Fix panic when checking S3 object existence during Vault initialization.

  ## Bug

  After migrating to AWS SDK v2 in commit d98e7cf5, the S3 storage backend panics with:
`panic: errors: *target must be interface or implement error`

  The issue occurs in `pkg/kv/s3/s3.go:98` when using `errors.As()` with
  `s3types.NoSuchKey`.

 ## How to reproduce

```
vault server -dev -config vault.hcl
```
```
# vault.hctl
api_addr = "http://localhost:8200"

storage "file" {
  path = "/tmp/vault"
}

listener "tcp" {
  address = "0.0.0.0:8200"
  tls_disable = true
}
```

```
VAULT_ADDR=http://127.0.0.1:8200 ./build/bank-vaults configure --aws-s3-bucket=baptiste-test-vault --mode=aws-kms-s3 --aws-s3-region=us-east-2 --vault-config-file=vault-config.yaml --aws-kms-region=us-east-2 --aws-kms-key-id=XXXXXXXXXXX
```
  
```
2025/11/17 14:31:19 INFO vault metrics exporter enabled: :9091/metrics
2025/11/17 14:31:19 INFO applying config file: vault-config.yaml
2025/11/17 14:31:19 INFO checking if vault is sealed...
2025/11/17 14:31:19 INFO watching directory for changes:
2025/11/17 14:31:19 INFO vault is unsealed, configuring...
panic: errors: *target must be interface or implement error
goroutine 1 [running]:
errors.As({0x3d04380, 0x40009c42a0}, {0x3202540, 0x4000cb41c8})
    /usr/local/go/src/errors/wrap.go:111 +0x1c0
emperror.dev/errors.As(...)
    /go/pkg/mod/emperror.dev/errors@v0.8.1/wrap_go1_13.go:26
github.com/bank-vaults/bank-vaults/pkg/kv/s3.(*s3Storage).Get(0x4000578ae0, {0x3d52e30, 0x40007fe000}, {0x36a94bd, 0xa})
    /bank-vaults/pkg/kv/s3/s3.go:98 +0x220
github.com/bank-vaults/bank-vaults/pkg/kv/multi.(*multi).Get(0x4000010750, {0x3d52e30, 0x40007fe000}, {0x36a94bd, 0xa})
    /bank-vaults/pkg/kv/multi/multi.go:52 +0x140
github.com/bank-vaults/bank-vaults/internal/vault.(*vault).RaftInitialized(0x4000080da0?, {0x3d52e30?, 0x40007fe000?})
    /bank-vaults/internal/vault/operator_client.go:379 +0x60
```

  ### Expected Behavior

  The operator should gracefully handle the missing key and return (false, nil) indicating Vault is not yet initialized - what is failing to get it initialized.


  ## Root Cause

  In AWS SDK v2, `*s3types.NoSuchKey` implements the `error` interface, not
  `s3types.NoSuchKey` (struct). The current code declares:
```go
var noSuchKeyError s3types.NoSuchKey
```

  When passed to `errors.As(err, &noSuchKeyError)`, this creates a `*s3types.NoSuchKey`
  target, but since the struct itself doesn't implement error, errors.As() panics since 
  `targetType = typ.Elem() = s3types.NoSuchKey`

```go
// As panics if target is not a non-nil pointer to either a type that implements
// error, or to any interface type.
func As(err error, target any) bool {
	if err == nil {
		return false
	}
	if target == nil {
		panic("errors: target cannot be nil")
	}
	val := reflectlite.ValueOf(target)
	typ := val.Type()
	if typ.Kind() != reflectlite.Ptr || val.IsNil() {
		panic("errors: target must be a non-nil pointer")
	}
	targetType := typ.Elem()
	if targetType.Kind() != reflectlite.Interface && !targetType.Implements(errorType) {
		panic("errors: *target must be interface or implement error")
	}
	return as(err, target, val, targetType)
}
```

## This PR

  Change the declaration to use a pointer type:
  var noSuchKeyError *s3types.NoSuchKey

  This allows errors.As() to properly match against *s3types.NoSuchKey errors returned
  by the AWS SDK v2.


`make build` 

```
VAULT_ADDR=http://127.0.0.1:8200 ./build/bank-vaults configure --aws-s3-bucket=baptiste-test-vault --mode=aws-kms-s3 --aws-s3-region=us-east-2 --vault-config-file=vault-config.yaml --aws-kms-region=us-east-2 --aws-kms-key-id=cfa1ef3e-6711-45d8-afed-1721a889182c
2025/11/17 14:32:23 INFO vault metrics exporter enabled: :9091/metrics
2025/11/17 14:32:23 INFO applying config file: vault-config.yaml
2025/11/17 14:32:23 INFO checking if vault is sealed...
2025/11/17 14:32:23 INFO watching directory for changes:
2025/11/17 14:32:23 INFO vault is unsealed, configuring...
2025/11/17 14:32:24 INFO error finding key "vault-root" in key/value Service, trying next one: failed to get data for KMS client: error getting object for key 'vault-root': operation error S3: GetObject, https response error StatusCode: 403, RequestID: 83RNGM92P3JNHVJR, HostID: XXXXXXXX, api error AccessDenied: User: arn:aws:sts::XXXXXXXX:assumed-role/XXXXXXXX/baptiste.lalanne@datadoghq.com is not authorized to perform: s3:ListBucket on resource: "arn:aws:s3:::baptiste-test-vault" because no identity-based policy allows the s3:ListBucket action
```
✅  No panic

